### PR TITLE
Feature/internal api not updated when a route is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### 🐛 Fixed
 - API reponds with an error message and status 500 if it's impossible to cast a variable 
+- API is updated when a route file is deleted
 
 ## [2.3.0] - 2021-08-03
 ### ✨ Added

--- a/src/Restapify.ts
+++ b/src/Restapify.ts
@@ -247,9 +247,10 @@ class Restapify {
         statusCode,
         fileContent
       } = routeData
-      const routeExist = this.routes[method][route] !== undefined
 
-      if (!routeExist) {
+      const routeExists = this.routes[method][route] !== undefined
+
+      if (!routeExists) {
         this.routes[method][route] = {} as RouteData
       }
 

--- a/src/Restapify.ts
+++ b/src/Restapify.ts
@@ -75,9 +75,7 @@ class Restapify {
   private server: any
   private chokidarWatcher: chokidar.FSWatcher
   private listedRouteFiles: ListedFiles = {}
-  public routes: Routes = {
-    GET: {}, POST: {}, DELETE: {}, PUT: {}, PATCH: {}
-  }
+  public routes: Routes
   public rootDir: string
   public port: number
   public publicPath: string
@@ -230,6 +228,11 @@ class Restapify {
   }
 
   private configRoutesFromListedFiles = (): void => {
+    // reset routes
+    this.routes = {
+      GET: {}, POST: {}, DELETE: {}, PUT: {}, PATCH: {}
+    }
+
     Object.keys(this.listedRouteFiles).forEach(routeFilePath => {
       const routeData = getRoute(
         routeFilePath,


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/johannchopin/restapify/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Explanation about your pull request, what changes you've made -->

Closes #71.

## Checklist

<!-- Ensure that all the tests passed -->
- [x] I compare my branch with `develop`
- [x] All tests passed after running `yarn test`
- [x] [Changelog](https://github.com/johannchopin/restapify/blob/main/CHANGELOG.md) has been updated
