### PR TITLE
🐛 Migrate from deprecated faker to @faker-js/faker and add CLI timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐛 Fixed
 - API reponds with an error message and status 500 if it's impossible to cast a variable 
 - API is updated when a route file is deleted
+- migrate from deprecated `faker` package to `@faker-js/faker` (#89)
+- add timestamp to CLI "API updated" log message (#91)
 
 ## [2.3.0] - 2021-08-03
 ### ✨ Added

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/express-serve-static-core": "^4.17.13",
-
     "@types/lodash.range": "^3.2.6",
     "@types/node": "^14.14.9",
     "@types/serve-static": "^1.13.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cors": "^2.8.5",
     "esm": "^3.2.25",
     "express": "^4.17.1",
-    "faker": "^5.2.0",
+    "@faker-js/faker": "^6.3.1",
     "http": "^0.0.1-security",
     "jsonschema": "^1.4.0",
     "lodash.range": "^3.2.0",
@@ -72,7 +72,7 @@
     "@types/cors": "^2.8.10",
     "@types/express": "^4.17.11",
     "@types/express-serve-static-core": "^4.17.13",
-    "@types/faker": "^5.1.5",
+
     "@types/lodash.range": "^3.2.6",
     "@types/node": "^14.14.9",
     "@types/serve-static": "^1.13.8",

--- a/src/__tests__/fakerjsIntegration.test.js
+++ b/src/__tests__/fakerjsIntegration.test.js
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import * as faker from 'faker';
+import { faker } from '@faker-js/faker';
 
 import { getRoute } from '../../src/getRoute'
 import { getFakerVarsInContent, getContentWithReplacedFakerVars, areFakerVarsSyntaxValidInContent } from '../../src/fakerHelpers'
@@ -7,18 +7,20 @@ import { getFakerVarsInContent, getContentWithReplacedFakerVars, areFakerVarsSyn
 // D A T A
 import getPostsById from '../../test/api/posts/[postid]/_.json'
 
-jest.mock('faker', () => ({
-  lorem: {
-    text: jest.fn().mockImplementation(() => 'fake' ),
-  },
-  internet: {
-    email: jest.fn().mockImplementation(() => 'fake@email.com' ),
-  },
-  time: {
-    recent: jest.fn().mockImplementation(() => 123 ),
-  },
-  datatype: {
-    boolean: jest.fn().mockImplementation(() => true )
+jest.mock('@faker-js/faker', () => ({
+  faker: {
+    lorem: {
+      text: jest.fn().mockImplementation(() => 'fake' ),
+    },
+    internet: {
+      email: jest.fn().mockImplementation(() => 'fake@email.com' ),
+    },
+    time: {
+      recent: jest.fn().mockImplementation(() => 123 ),
+    },
+    datatype: {
+      boolean: jest.fn().mockImplementation(() => true )
+    }
   }
 }))
 

--- a/src/__tests__/forLoop.test.js
+++ b/src/__tests__/forLoop.test.js
@@ -6,12 +6,14 @@ import {
   isStatementObjectValid
 } from '../../src/forLoopHelpers'
 
-jest.mock('faker', () => ({
-  internet: {
-    email: jest.fn().mockImplementation(() => 'fake@email.com' ),
-  },
-  datatype: {
-    boolean: jest.fn().mockImplementation(() => true )
+jest.mock('@faker-js/faker', () => ({
+  faker: {
+    internet: {
+      email: jest.fn().mockImplementation(() => 'fake@email.com' ),
+    },
+    datatype: {
+      boolean: jest.fn().mockImplementation(() => true )
+    }
   }
 }))
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -123,7 +123,9 @@ export const runServer = (config: RestapifyParams): void => {
   })
 
   rpfy.on('server:restart', () => {
-    console.log(chalk.green('✅ API updated!'))
+    const now = new Date()
+    const timestamp = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`
+    console.log(chalk.green(`[${timestamp}] ✅ API updated!`))
   })
 
   rpfy.run()

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -1,4 +1,4 @@
-import faker from 'faker'
+import { faker } from '@faker-js/faker'
 import { RestapifyErrorName } from './types/restapify'
 
 export type FakerLocale = 'az' | 'ar' | 'cz' | 'de' | 'de_AT' | 'de_CH' | 'en' | 'en_AU' | 'en_AU_ocker' | 'en_BORK' | 'en_CA' | 'en_GB' | 'en_IE' | 'en_IND' | 'en_US' | 'en_ZA' | 'es' | 'es_MX' | 'fa' | 'fi' | 'fr' | 'fr_CA' | 'fr_CH' | 'ge' | 'hy' | 'hr' | 'id_ID' | 'it' | 'ja' | 'ko' | 'nb_NO' | 'ne' | 'nl' | 'nl_BE' | 'pl' | 'pt_BR' | 'pt_PT' | 'ro' | 'ru' | 'sk' | 'sv' | 'tr' | 'uk' | 'vi' | 'zh_CN' | 'zh_TW'

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.3.1.tgz#1ae963dd40405450a2945408cba553e1afa3e0fb"
+  integrity sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1433,11 +1438,6 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
-
-"@types/faker@^5.1.5":
-  version "5.5.7"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.7.tgz#52aa3ad6ead3642b7c54e1e87e9e3ff5b10b3873"
-  integrity sha512-ejzb61Q5zQTtS0ZIafgQ7ahO5ACzmGhG5PfX2hxWyth3k0/aysb4ZOxKQB8DbzwSPppA5jmFBwqnBxjv5hqI5Q==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
@@ -3403,11 +3403,6 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-faker@^5.2.0:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
Migrates from the deprecated/unmaintained `faker` package to the community maintained `@faker-js/faker` v6 ( fixes #89 ) and adds a `[HH:MM:SS]` timestamp prefix to the "API updated" CLI log message (fixes #91)

- `src/faker.ts` -> updated the import from `import faker from 'faker'` to `import { faker } from '@faker-js/faker'` (named export)
- `package.json` -> replaced `faker: ^5.2.0` with `@faker-js/faker: ^6.3.1`, removed `@types/faker` ( the new package ships its own types)
- Test files -> updated `jest.mock('faker', ...)` to `jest.mock('@faker-js/faker', ...)` with the nested `faker` named export structure
- `src/cli/utils.ts` -> added `[HH:MM:SS]` timestamp to the `server:restart` log output
- `CHANGELOG.md` -> updated

----------------------

- The old `faker` package was [compromised and abandoned](https://fakerjs.dev/) and it fails to install/import on modern Node.js
- The `@faker-js/faker` v6 API is backward-compatible - `faker[namespace][method]()` calls and `faker.locale` work identically
- The CLI timestamp addresses the UX issue in #91 

- [x] I compare my branch with `develop`
- [x] All tests passed after running `yarn test`
- [x] [Changelog](https://github.com/johannchopin/restapify/blob/main/CHANGELOG.md) has been updated